### PR TITLE
Remove Jpype <= 1.4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         java-version: ["8", "11", "17"]
 
     steps:

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,11 +36,7 @@ setup(name='cogroo4py',
           'jpype-stubs': jpype_stubs_paths,
           'org-stubs': org_stubs_paths
       },
-      install_requires=[
-        'JPype1>=1.3.0,<=1.4.0; python_version<3.11',
-        'JPype1>=1.4.1; python_version>=3.11',
-        'Deprecated==1.2.13'
-      ],
+      install_requires=['JPype1>=1.3.0,<=1.4.1', 'Deprecated==1.2.13'],
       extras_require={
           'dev': ['stubgenj==0.2.5']
       },

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,11 @@ setup(name='cogroo4py',
           'jpype-stubs': jpype_stubs_paths,
           'org-stubs': org_stubs_paths
       },
-      install_requires=['JPype1>=1.4.1', 'Deprecated==1.2.13'],
+      install_requires=[
+        'JPype1>=1.3.0,<=1.4.0; python_version<3.11',
+        'JPype1>=1.4.1; python_version>=3.11',
+        'Deprecated==1.2.13'
+      ],
       extras_require={
           'dev': ['stubgenj==0.2.5']
       },

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(name='cogroo4py',
           'jpype-stubs': jpype_stubs_paths,
           'org-stubs': org_stubs_paths
       },
-      install_requires=['JPype1>=1.4.0', 'Deprecated==1.2.13'],
+      install_requires=['JPype1>=1.4.1', 'Deprecated==1.2.13'],
       extras_require={
           'dev': ['stubgenj==0.2.5']
       },

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(name='cogroo4py',
           'jpype-stubs': jpype_stubs_paths,
           'org-stubs': org_stubs_paths
       },
-      install_requires=['JPype1>=1.3.0,<=1.4.0', 'Deprecated==1.2.13'],
+      install_requires=['JPype1>=1.4.0', 'Deprecated==1.2.13'],
       extras_require={
           'dev': ['stubgenj==0.2.5']
       },


### PR DESCRIPTION
New releases of python (3.11) have known issues on old versions of Jpype. So we need to add upgrade on package.